### PR TITLE
Fix "Failed to get AMS mapping table" (0700_8012) on printers without AMS

### DIFF
--- a/backend/app/services/bambu_mqtt.py
+++ b/backend/app/services/bambu_mqtt.py
@@ -2760,6 +2760,32 @@ class BambuMQTTClient:
                         self.serial_number,
                     )
 
+            # --- No-AMS external spool fix ---
+            # On printers without a physical AMS (P2S, A1, P1S without AMS, etc.)
+            # the external spool is the only filament source.  The firmware
+            # rejects -1 (unmapped) and 254 (virtual tray ID) in ams_mapping
+            # with 0700_8012 "Failed to get AMS mapping table".
+            #
+            # The fix: remap all -1 entries to 0 in the flat ams_mapping so the
+            # firmware's mapping table validation passes, and omit ams_mapping2
+            # entirely — including it with virtual tray IDs (254/255) re-triggers
+            # the error, and including it with ams_id 0 causes the firmware to
+            # attempt an AMS filament load from a non-existent unit.
+            #
+            # With ams_mapping=[0] + use_ams=false + no ams_mapping2, the
+            # firmware uses the already-loaded external spool without any AMS
+            # interaction.
+            #
+            # H2D series is excluded — use_ams controls nozzle routing on those.
+            no_ams_printer = not use_ams and not is_h2d and not self.state.raw_data.get("ams")
+            if no_ams_printer and flat_ams_mapping:
+                flat_ams_mapping = [0 if v == -1 else v for v in flat_ams_mapping]
+                logger.info(
+                    "[%s] No AMS detected — remapped external spool: ams_mapping=%s, omitting ams_mapping2",
+                    self.serial_number,
+                    flat_ams_mapping,
+                )
+
             command = {
                 "print": {
                     "sequence_id": "20000",
@@ -2803,7 +2829,8 @@ class BambuMQTTClient:
             # Add AMS mapping if provided
             if ams_mapping is not None:
                 command["print"]["ams_mapping"] = flat_ams_mapping
-                command["print"]["ams_mapping2"] = ams_mapping2
+                if not no_ams_printer:
+                    command["print"]["ams_mapping2"] = ams_mapping2
 
             logger.info("[%s] Sending print command: %s", self.serial_number, json.dumps(command))
             self._client.publish(self.topic_publish, json.dumps(command), qos=1)


### PR DESCRIPTION
**Problem**

When starting a print via MQTT on a P2S (or any printer) without a physical AMS connected, the print would start but immediately fail with error `0700_8012` "Failed to get AMS mapping table". The same 3MF file printed fine from the printer's touchscreen.

**Root cause**

The `start_print()` method in `bambu_mqtt.py` sent `ams_mapping: [-1]` (unmapped) and `ams_mapping2: [{"ams_id": 254, "slot_id": 0}]` (virtual tray) for external spool prints. On printers without AMS hardware, the firmware rejects both `-1` and `254` in the mapping arrays — it tries to build an AMS mapping table from these values and fails because no AMS exists.

**What was tried (and why it didn't work)**

| Approach | Result |
|---|---|
| `ams_mapping: [-1]` (original) | Mapping table error |
| `ams_mapping: [254]` | Mapping table error |
| `ams_mapping: ""` (empty string) | Mapping table error |
| Omit `ams_mapping` entirely | Mapping table error |
| `ams_mapping: [-1,-1,-1,-1,-1]` (5-element pad) | Mapping table error |
| `ams_mapping: [0]` + `ams_mapping2: [{"ams_id": 0, "slot_id": 0}]` | No mapping error, but firmware tried to load filament from non-existent AMS unit 0 |
| `ams_mapping: [0]` + `ams_mapping2: [{"ams_id": 254, "slot_id": 0}]` | Mapping table error (254 in mapping2 triggers it) |

**Fix**

For printers without AMS (`use_ams=false`, no AMS units in printer state, not H2D series):
1. Remap `-1` entries in `flat_ams_mapping` to `0` — this passes the firmware's mapping table validation
2. Omit `ams_mapping2` entirely — any value in it either re-triggers the mapping error (254) or causes unwanted filament load attempts (0)

The resulting MQTT command sends `"ams_mapping": [0], "use_ams": false` with no `ams_mapping2`. The firmware accepts the mapping table and uses the already-loaded external spool filament without AMS interaction.

**Scope**

The fix only activates when all three conditions are met:
- `use_ams` is `false`
- Printer is not H2D series (where `use_ams` controls nozzle routing)
- No AMS units reported in printer state (`self.state.raw_data.get("ams")` is empty/absent)

Tested on P2S and A1 without AMS.