### PR TITLE
Cache camera snapshots briefly

### DIFF
--- a/backend/app/api/routes/camera.py
+++ b/backend/app/api/routes/camera.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import subprocess
 import sys
+import time
 import uuid
 from collections.abc import AsyncGenerator
 
@@ -61,6 +62,12 @@ _last_frame_times: dict[int, float] = {}
 
 # Track stream start times for each printer
 _stream_start_times: dict[int, float] = {}
+
+# Store recent one-shot snapshots to avoid opening a fresh camera connection
+# for every Cam Wall poll when no live stream is attached.
+_snapshot_frames: dict[int, bytes] = {}
+_snapshot_frame_times: dict[int, float] = {}
+_SNAPSHOT_CACHE_TTL_SECONDS = 5.0
 
 # Track active external camera streams by printer ID
 _active_external_streams: set[int] = set()
@@ -179,6 +186,38 @@ def _release_printer_frame_state(printer_id: int | None) -> None:
     _last_frames.pop(printer_id, None)
     _last_frame_times.pop(printer_id, None)
     _stream_start_times.pop(printer_id, None)
+    _snapshot_frames.pop(printer_id, None)
+    _snapshot_frame_times.pop(printer_id, None)
+
+
+def _snapshot_response(printer_id: int, image_data: bytes) -> Response:
+    return Response(
+        content=image_data,
+        media_type="image/jpeg",
+        headers={
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Content-Disposition": f'inline; filename="snapshot_{printer_id}.jpg"',
+        },
+    )
+
+
+def _get_cached_snapshot(printer_id: int) -> bytes | None:
+    image_data = _snapshot_frames.get(printer_id)
+    if image_data is None:
+        return None
+
+    captured_at = _snapshot_frame_times.get(printer_id, 0.0)
+    if time.monotonic() - captured_at > _SNAPSHOT_CACHE_TTL_SECONDS:
+        _snapshot_frames.pop(printer_id, None)
+        _snapshot_frame_times.pop(printer_id, None)
+        return None
+
+    return image_data
+
+
+def _remember_snapshot(printer_id: int, image_data: bytes) -> None:
+    _snapshot_frames[printer_id] = image_data
+    _snapshot_frame_times[printer_id] = time.monotonic()
 
 
 def try_get_active_buffered_frame(printer_id: int) -> bytes | None:
@@ -1102,6 +1141,10 @@ async def camera_snapshot(
     if printer.external_camera_enabled and printer.external_camera_url:
         from backend.app.services.external_camera import capture_frame
 
+        cached = _get_cached_snapshot(printer_id)
+        if cached is not None:
+            return _snapshot_response(printer_id, cached)
+
         frame_data = await capture_frame(
             printer.external_camera_url,
             printer.external_camera_type,
@@ -1113,14 +1156,8 @@ async def camera_snapshot(
                 status_code=503,
                 detail="Failed to capture frame from external camera.",
             )
-        return Response(
-            content=frame_data,
-            media_type="image/jpeg",
-            headers={
-                "Cache-Control": "no-cache, no-store, must-revalidate",
-                "Content-Disposition": f'inline; filename="snapshot_{printer_id}.jpg"',
-            },
-        )
+        _remember_snapshot(printer_id, frame_data)
+        return _snapshot_response(printer_id, frame_data)
 
     # If a live fan-out stream is already running for this printer, reuse
     # the broadcaster's buffered frame instead of opening a competing RTSP
@@ -1131,14 +1168,11 @@ async def camera_snapshot(
     # Upstream Bambuddy #1271 / commit c097140e.
     buffered = try_get_active_buffered_frame(printer_id)
     if buffered is not None:
-        return Response(
-            content=buffered,
-            media_type="image/jpeg",
-            headers={
-                "Cache-Control": "no-cache, no-store, must-revalidate",
-                "Content-Disposition": f'inline; filename="snapshot_{printer_id}.jpg"',
-            },
-        )
+        return _snapshot_response(printer_id, buffered)
+
+    cached = _get_cached_snapshot(printer_id)
+    if cached is not None:
+        return _snapshot_response(printer_id, cached)
 
     # Create temporary file for the snapshot
     import os
@@ -1167,14 +1201,8 @@ async def camera_snapshot(
         with open(temp_path, "rb") as f:
             image_data = f.read()
 
-        return Response(
-            content=image_data,
-            media_type="image/jpeg",
-            headers={
-                "Cache-Control": "no-cache, no-store, must-revalidate",
-                "Content-Disposition": f'inline; filename="snapshot_{printer_id}.jpg"',
-            },
-        )
+        _remember_snapshot(printer_id, image_data)
+        return _snapshot_response(printer_id, image_data)
     finally:
         # Clean up temp file
         if temp_path.exists():

--- a/backend/tests/integration/test_camera_api.py
+++ b/backend/tests/integration/test_camera_api.py
@@ -36,6 +36,17 @@ async def _inject_camera_stream_token(async_client: AsyncClient):
     async_client.get = original_get  # type: ignore[method-assign]
 
 
+@pytest.fixture(autouse=True)
+def _clear_snapshot_cache():
+    from backend.app.api.routes import camera
+
+    camera._snapshot_frames.clear()
+    camera._snapshot_frame_times.clear()
+    yield
+    camera._snapshot_frames.clear()
+    camera._snapshot_frame_times.clear()
+
+
 class TestCameraAPI:
     """Integration tests for /api/v1/printers/{id}/camera/ endpoints."""
 
@@ -209,6 +220,63 @@ class TestCameraAPI:
 
         # Note: The actual test might fail due to file operations, but this tests the endpoint structure
         # In production tests, we'd mock more comprehensively
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_camera_snapshot_reuses_recent_capture(self, async_client: AsyncClient, printer_factory):
+        """Verify rapid snapshot polls reuse the previous successful capture."""
+        printer = await printer_factory()
+        fake_jpeg = b"\xff\xd8first-cached-frame"
+
+        with (
+            patch("backend.app.api.routes.camera.capture_camera_frame", new_callable=AsyncMock) as mock_capture,
+            patch("builtins.open", create=True) as mock_open,
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.unlink"),
+        ):
+            mock_capture.return_value = True
+            mock_open.return_value.__enter__.return_value.read.return_value = fake_jpeg
+
+            first = await async_client.get(f"/api/v1/printers/{printer.id}/camera/snapshot")
+            second = await async_client.get(f"/api/v1/printers/{printer.id}/camera/snapshot")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.content == fake_jpeg
+        assert second.content == fake_jpeg
+        mock_capture.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_camera_snapshot_recaptures_after_cache_expires(self, async_client: AsyncClient, printer_factory):
+        """Verify snapshot cache expires and a later poll captures again."""
+        from backend.app.api.routes import camera
+
+        printer = await printer_factory()
+        now = 1000.0
+        fake_jpegs = [b"\xff\xd8first-frame", b"\xff\xd8second-frame"]
+
+        async def fake_capture(*, output_path, **_kwargs):
+            output_path.write_bytes(fake_jpegs.pop(0))
+            return True
+
+        with (
+            patch("backend.app.api.routes.camera.time.monotonic", side_effect=lambda: now),
+            patch("backend.app.api.routes.camera.capture_camera_frame", new_callable=AsyncMock) as mock_capture,
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.unlink"),
+        ):
+            mock_capture.side_effect = fake_capture
+
+            first = await async_client.get(f"/api/v1/printers/{printer.id}/camera/snapshot")
+            now += camera._SNAPSHOT_CACHE_TTL_SECONDS + 0.1
+            second = await async_client.get(f"/api/v1/printers/{printer.id}/camera/snapshot")
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert first.content == b"\xff\xd8first-frame"
+        assert second.content == b"\xff\xd8second-frame"
+        assert mock_capture.await_count == 2
 
     @pytest.mark.asyncio
     @pytest.mark.integration


### PR DESCRIPTION
## Summary

- Add a short server-side cache for successful `/camera/snapshot` responses.
- Reuse cached frames for rapid Cam Wall polling instead of opening a fresh camera capture/ffmpeg process on every request.
- Keep active live stream buffers ahead of the cache for built-in cameras, so viewers still get the freshest fan-out frame when one is available.
- Share snapshot response construction and cover cache reuse/expiry behavior with integration tests.

## Motivation

On a local BamDude install with multiple Bambu X1C printers, the browser Cam Wall snapshot polling repeatedly hit `/api/v1/printers/{id}/camera/snapshot`. When no live fan-out buffer was attached, each poll opened a fresh capture path and spawned ffmpeg. That drove sustained high container CPU and made printer video/snapshot state flaky.

A 5 second in-process cache is enough to collapse bursts of identical polling while still keeping snapshots fresh for UI use. Failed captures are not cached.

## Testing

- `.venv\Scripts\python.exe -m ruff check backend\app\api\routes\camera.py backend\tests\integration\test_camera_api.py`
- `.venv\Scripts\python.exe -m pytest backend/tests/integration/test_camera_api.py -q` (`35 passed`)
- `python -m py_compile backend\app\api\routes\camera.py backend\tests\integration\test_camera_api.py`
