### PR TITLE
Add optional VAAPI hwaccel for RTSP camera streams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,15 @@ LOG_TO_FILE=true
 # bundle ffmpeg, so this is typically a local-Windows-dev-only override.
 # FFMPEG_PATH=C:\Users\you\AppData\Local\Microsoft\WinGet\Packages\Gyan.FFmpeg_...\ffmpeg-8.1.2-full_build\bin\ffmpeg.exe
 
+# Optional hardware decode for built-in RTSP camera streams (X1 / X2 / H2 / P2).
+# Default is software decode. Set to vaapi on Linux hosts where /dev/dri is
+# passed into the container and the container user has access to the render
+# device. The MJPEG output contract is unchanged; only ffmpeg's input decode
+# path moves to VAAPI.
+# BAMDUDE_RTSP_HWACCEL=vaapi
+# BAMDUDE_VAAPI_DEVICE=/dev/dri/renderD128
+# LIBVA_DRIVER_NAME=iHD
+
 # =============================================================================
 # Database
 # =============================================================================

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -108,6 +108,31 @@ volumes:
   bamdude_logs:
 ```
 
+### Optional RTSP hardware decode on Linux
+
+Built-in RTSP camera streams can opt into ffmpeg VAAPI hardware decode. Pass
+the host render device into the container, add matching `video`/`render` group
+access, and set:
+
+```yaml
+services:
+  bamdude:
+    environment:
+      - BAMDUDE_RTSP_HWACCEL=vaapi
+      - BAMDUDE_VAAPI_DEVICE=/dev/dri/renderD128
+      - LIBVA_DRIVER_NAME=iHD
+    volumes:
+      - /dev/dri:/dev/dri
+    group_add:
+      - "<video-gid>"
+      - "<render-gid>"
+```
+
+Use `getent group video render` on the host to find the numeric group IDs.
+Older Intel GPUs may need `LIBVA_DRIVER_NAME=i965`. The frontend/API contract
+does not change: BamDude still serves MJPEG, but ffmpeg can decode the RTSP
+input through VAAPI.
+
 ## Upgrading & migration
 
 Full manual (every source version × every install method, backup/rollback, troubleshooting):

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     gosu \
     iproute2 \
+    i965-va-driver \
+    intel-media-va-driver \
+    libva-drm2 \
+    libva2 \
     libcap2-bin \
     openssh-client \
+    vainfo \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,31 @@ Open **http://localhost:8000** in your browser.
 
 > **macOS/Windows:** Docker Desktop doesn't support `--network host`. Use `-p 8000:8000` instead and add printers manually by IP.
 
+#### Optional RTSP hardware decode on Linux
+
+Built-in RTSP camera streams can opt into ffmpeg VAAPI hardware decode:
+
+```bash
+docker run -d \
+  --name bamdude \
+  --network host \
+  --device /dev/dri:/dev/dri \
+  --group-add "$(getent group video | cut -d: -f3)" \
+  --group-add "$(getent group render | cut -d: -f3)" \
+  -e BAMDUDE_RTSP_HWACCEL=vaapi \
+  -e BAMDUDE_VAAPI_DEVICE=/dev/dri/renderD128 \
+  -e LIBVA_DRIVER_NAME=iHD \
+  -e TZ=Europe/Kyiv \
+  -v bamdude_data:/app/data \
+  -v bamdude_logs:/app/logs \
+  --restart unless-stopped \
+  kainpl/bamdude:latest
+```
+
+Older Intel GPUs may need `LIBVA_DRIVER_NAME=i965` instead of `iHD`.
+When disabled or unavailable, BamDude keeps using software decode and the
+MJPEG camera output stays unchanged.
+
 ### Docker Compose (from source)
 
 ```bash

--- a/backend/app/api/routes/camera.py
+++ b/backend/app/api/routes/camera.py
@@ -42,6 +42,11 @@ from backend.app.services.camera_fanout import (
     shutdown_broadcaster,
 )
 from backend.app.services.camera_profiles import get_camera_profile
+from backend.app.services.ffmpeg_hwaccel import (
+    rtsp_hwaccel_filter_args,
+    rtsp_hwaccel_input_args,
+    rtsp_hwaccel_mode,
+)
 from backend.app.services.ffmpeg_stderr import FfmpegStderrDrain
 
 logger = logging.getLogger(__name__)
@@ -468,6 +473,7 @@ async def generate_rtsp_mjpeg_stream(
     # hardened Debian defaults rejecting TLS renegotiation.
     proxy_port, proxy_server = await create_tls_proxy(ip_address, port)
     camera_url = f"rtsp://bblp:{access_code}@127.0.0.1:{proxy_port}/streaming/live/1"
+    hwaccel_mode = rtsp_hwaccel_mode()
 
     # ffmpeg command to output MJPEG stream to stdout
     cmd = [
@@ -501,8 +507,10 @@ async def generate_rtsp_mjpeg_stream(
         "-flags",
         "low_delay",  # Minimize decode latency
         *profile.extra_ffmpeg_input_args,
+        *rtsp_hwaccel_input_args(hwaccel_mode),
         "-i",
         camera_url,
+        *rtsp_hwaccel_filter_args(hwaccel_mode),
         "-f",
         "mjpeg",
         "-q:v",
@@ -518,13 +526,14 @@ async def generate_rtsp_mjpeg_stream(
         _disconnect_events[stream_id] = disconnect_event
 
     logger.info(
-        "Starting RTSP camera stream for %s (stream_id=%s, model=%s, fps=%s, probesize=%s, analyzeduration=%s)",
+        "Starting RTSP camera stream for %s (stream_id=%s, model=%s, fps=%s, probesize=%s, analyzeduration=%s, hwaccel=%s)",
         ip_address,
         stream_id,
         model,
         fps,
         profile.probesize,
         profile.analyzeduration,
+        hwaccel_mode or "software",
     )
     # Log the full argv so a support bundle shows the actual ffmpeg flags
     # (probesize, analyzeduration, transport, ...). Only camera_url carries a

--- a/backend/app/services/ffmpeg_hwaccel.py
+++ b/backend/app/services/ffmpeg_hwaccel.py
@@ -1,0 +1,60 @@
+"""Optional ffmpeg hardware acceleration flags for camera streams."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_DISABLED_VALUES = {"", "0", "false", "no", "none", "off"}
+_SUPPORTED_MODES = {"vaapi"}
+_DEFAULT_VAAPI_DEVICE = "/dev/dri/renderD128"
+
+
+def rtsp_hwaccel_mode() -> str | None:
+    """Return the requested RTSP hwaccel mode, or ``None`` when disabled.
+
+    The switch is intentionally opt-in. Most installs do not mount GPU devices
+    into the container, so silently keeping software decode as the default is
+    the least surprising behaviour.
+    """
+    mode = os.environ.get("BAMDUDE_RTSP_HWACCEL", "").strip().lower()
+    if mode in _DISABLED_VALUES:
+        return None
+    if mode in _SUPPORTED_MODES:
+        return mode
+    logger.warning("Unsupported BAMDUDE_RTSP_HWACCEL=%r; using software decode", mode)
+    return None
+
+
+def rtsp_hwaccel_input_args(mode: str | None = None) -> tuple[str, ...]:
+    """ffmpeg input-side args for the selected RTSP hwaccel mode."""
+    selected = rtsp_hwaccel_mode() if mode is None else mode
+    if selected != "vaapi":
+        return ()
+    device = os.environ.get("BAMDUDE_VAAPI_DEVICE", _DEFAULT_VAAPI_DEVICE).strip() or _DEFAULT_VAAPI_DEVICE
+    return (
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_device",
+        device,
+        "-hwaccel_output_format",
+        "vaapi",
+    )
+
+
+def rtsp_hwaccel_filter_args(mode: str | None = None) -> tuple[str, ...]:
+    """ffmpeg output-side filter args required after VAAPI decode.
+
+    BamDude still emits MJPEG on stdout for the frontend/API contract. VAAPI
+    decoded frames therefore have to be downloaded back to software frames
+    before ffmpeg's MJPEG encoder sees them.
+    """
+    selected = rtsp_hwaccel_mode() if mode is None else mode
+    if selected != "vaapi":
+        return ()
+    return ("-vf", "hwdownload,format=nv12")
+
+
+__all__ = ["rtsp_hwaccel_filter_args", "rtsp_hwaccel_input_args", "rtsp_hwaccel_mode"]

--- a/backend/tests/unit/services/test_ffmpeg_hwaccel.py
+++ b/backend/tests/unit/services/test_ffmpeg_hwaccel.py
@@ -1,0 +1,60 @@
+"""Unit tests for optional ffmpeg hardware acceleration flags."""
+
+from __future__ import annotations
+
+from backend.app.services.ffmpeg_hwaccel import (
+    rtsp_hwaccel_filter_args,
+    rtsp_hwaccel_input_args,
+    rtsp_hwaccel_mode,
+)
+
+
+def test_rtsp_hwaccel_is_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("BAMDUDE_RTSP_HWACCEL", raising=False)
+
+    assert rtsp_hwaccel_mode() is None
+    assert rtsp_hwaccel_input_args() == ()
+    assert rtsp_hwaccel_filter_args() == ()
+
+
+def test_rtsp_hwaccel_accepts_common_disabled_values(monkeypatch):
+    for value in ("0", "false", "no", "none", "off", " "):
+        monkeypatch.setenv("BAMDUDE_RTSP_HWACCEL", value)
+        assert rtsp_hwaccel_mode() is None
+
+
+def test_unknown_rtsp_hwaccel_mode_falls_back_to_software(monkeypatch, caplog):
+    monkeypatch.setenv("BAMDUDE_RTSP_HWACCEL", "cuda")
+
+    assert rtsp_hwaccel_mode() is None
+    assert "Unsupported BAMDUDE_RTSP_HWACCEL" in caplog.text
+
+
+def test_vaapi_rtsp_hwaccel_uses_default_render_node(monkeypatch):
+    monkeypatch.setenv("BAMDUDE_RTSP_HWACCEL", "vaapi")
+    monkeypatch.delenv("BAMDUDE_VAAPI_DEVICE", raising=False)
+
+    assert rtsp_hwaccel_mode() == "vaapi"
+    assert rtsp_hwaccel_input_args() == (
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_device",
+        "/dev/dri/renderD128",
+        "-hwaccel_output_format",
+        "vaapi",
+    )
+    assert rtsp_hwaccel_filter_args() == ("-vf", "hwdownload,format=nv12")
+
+
+def test_vaapi_rtsp_hwaccel_allows_custom_render_node(monkeypatch):
+    monkeypatch.setenv("BAMDUDE_RTSP_HWACCEL", "VAAPI")
+    monkeypatch.setenv("BAMDUDE_VAAPI_DEVICE", "/dev/dri/renderD129")
+
+    assert rtsp_hwaccel_input_args() == (
+        "-hwaccel",
+        "vaapi",
+        "-hwaccel_device",
+        "/dev/dri/renderD129",
+        "-hwaccel_output_format",
+        "vaapi",
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,11 @@ services:
       # system trust store on container startup. Enable trust-store loading
       # with USE_SYSTEM_TRUST_STORE=true in the environment block below.
       #- /path/to/certs:/usr/local/share/ca-certificates
+      #
+      # Optional VAAPI hardware decode for built-in RTSP camera streams.
+      # Uncomment this together with BAMDUDE_RTSP_HWACCEL=vaapi below. On older
+      # Intel GPUs (for example Ivy Bridge), also set LIBVA_DRIVER_NAME=i965.
+      #- /dev/dri:/dev/dri
     environment:
       - TZ=${TZ:-Europe/Kyiv}
       # User/group the container drops to after the entrypoint normalises
@@ -120,6 +125,18 @@ services:
       # use case: a local Home Assistant instance with a self-signed cert
       # that BamDude needs to talk to over HTTPS.
       #- USE_SYSTEM_TRUST_STORE=true
+      #
+      # Optional ffmpeg VAAPI hardware decode for built-in RTSP camera streams.
+      # Requires /dev/dri above and matching render/video group access. If your
+      # device node is not renderD128, override BAMDUDE_VAAPI_DEVICE.
+      #- BAMDUDE_RTSP_HWACCEL=vaapi
+      #- BAMDUDE_VAAPI_DEVICE=/dev/dri/renderD128
+      #- LIBVA_DRIVER_NAME=iHD
+    # Optional VAAPI group access. Use numeric host IDs from:
+    #   getent group video render
+    #group_add:
+    #  - "${BAMDUDE_VIDEO_GID:-44}"
+    #  - "${BAMDUDE_RENDER_GID:-109}"
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Description

Adds an opt-in VAAPI hardware decode path for built-in RTSP camera streams while keeping BamDude's existing MJPEG output contract unchanged. By default, RTSP streams continue to use software decode.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test addition or update

## Changes Made

- Added `BAMDUDE_RTSP_HWACCEL=vaapi` and `BAMDUDE_VAAPI_DEVICE` support for RTSP ffmpeg streams.
- Added VAAPI ffmpeg input flags and the required `hwdownload,format=nv12` filter before MJPEG output.
- Added Intel VAAPI runtime packages to the Docker image (`i965-va-driver`, `intel-media-va-driver`, `libva*`, `vainfo`).
- Documented `/dev/dri`, `video`/`render` group access, and `LIBVA_DRIVER_NAME` (`iHD` by default, `i965` for older Intel GPUs such as Ivy Bridge).
- Added unit tests for disabled/default behaviour, unsupported modes, default VAAPI device, and custom VAAPI device.

## Screenshots

N/A

## Testing

- [x] `python -m ruff check backend/app/services/ffmpeg_hwaccel.py backend/tests/unit/services/test_ffmpeg_hwaccel.py backend/app/api/routes/camera.py`
- [x] `python -m ruff format --check backend/app/services/ffmpeg_hwaccel.py backend/tests/unit/services/test_ffmpeg_hwaccel.py`
- [x] `python -m py_compile backend/app/services/ffmpeg_hwaccel.py backend/app/api/routes/camera.py backend/tests/unit/services/test_ffmpeg_hwaccel.py`
- [ ] Full pytest locally: not run in this checkout because the local Python environment is missing test dependency `aiosqlite`.
- [x] Tested equivalent deployment settings on Intel Ivy Bridge + X1C RTSP streams.

## Checklist

- [x] My code follows the project's coding style
- [x] I have commented my code where necessary
- [x] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly

## Additional Notes

Deployment used for the performance check:

- `/dev/dri` passed into the container
- `video`/`render` group access added
- Intel VAAPI drivers available
- `LIBVA_DRIVER_NAME=i965`
- `BAMDUDE_RTSP_HWACCEL=vaapi`
- Output kept at 5 FPS / width 320 in the deployment

Observed result with 3 simultaneous RTSP -> MJPEG streams: CPU dropped from roughly `20% / 20% / 31%` per stream to about `7-9% / 7-9% / 15%`. No frontend/API contract change; clients still receive MJPEG.